### PR TITLE
Fixes incorrect delegate setup causing retain cycles

### DIFF
--- a/Photo Editor/Photo Editor/PhotoEditorViewController.swift
+++ b/Photo Editor/Photo Editor/PhotoEditorViewController.swift
@@ -49,7 +49,7 @@ public final class PhotoEditorViewController: UIViewController {
      */
     public var colors  : [UIColor] = []
     
-    public var photoEditorDelegate: PhotoEditorDelegate?
+    public weak var photoEditorDelegate: PhotoEditorDelegate?
     var colorsCollectionViewDelegate: ColorsCollectionViewDelegate!
     
     // list of controls to be hidden

--- a/Photo Editor/Photo Editor/Protocols.swift
+++ b/Photo Editor/Photo Editor/Protocols.swift
@@ -14,7 +14,7 @@ import UIKit
  - stickersViewDidDisappear
  */
 
-public protocol PhotoEditorDelegate {
+public protocol PhotoEditorDelegate: class {
     /**
      - Parameter image: edited Image
      */


### PR DESCRIPTION
Commit message says it all; PhotoEditorViewController incorrectly didn't use `weak` for a delegate paradigm.