### PR TITLE
Fix: App crash in iPad

### DIFF
--- a/Photo Editor/Photo Editor/CropViewController.swift
+++ b/Photo Editor/Photo Editor/CropViewController.swift
@@ -218,6 +218,10 @@ open class CropViewController: UIViewController {
         }
         actionSheet.addAction(cancel)
         
+        if let popoverController = actionSheet.popoverPresentationController {
+            popoverController.barButtonItem = sender
+        }
+        
         present(actionSheet, animated: true, completion: nil)
     }
 


### PR DESCRIPTION
Fixing when constrain action sheet is presented, iPad will crash. 