### PR TITLE
Fix drawing issues

### DIFF
--- a/Example/Pods/iOSPhotoEditor/Photo Editor/Photo Editor/PhotoEditor+Drawing.swift
+++ b/Example/Pods/iOSPhotoEditor/Photo Editor/Photo Editor/PhotoEditor+Drawing.swift
@@ -58,9 +58,10 @@ extension PhotoEditorViewController {
     
     func drawLineFrom(_ fromPoint: CGPoint, toPoint: CGPoint) {
         // 1
-        UIGraphicsBeginImageContext(canvasImageView.frame.size)
+		let canvasSize = canvasImageView.frame.integral.size
+        UIGraphicsBeginImageContext(canvasSize)
         if let context = UIGraphicsGetCurrentContext() {
-            canvasImageView.image?.draw(in: CGRect(x: 0, y: 0, width: canvasImageView.frame.size.width, height: canvasImageView.frame.size.height))
+            canvasImageView.image?.draw(in: CGRect(x: 0, y: 0, width: canvasSize.width, height: canvasSize.height))
             // 2
             context.move(to: CGPoint(x: fromPoint.x, y: fromPoint.y))
             context.addLine(to: CGPoint(x: toPoint.x, y: toPoint.y))

--- a/Example/Pods/iOSPhotoEditor/Photo Editor/Photo Editor/PhotoEditor+Drawing.swift
+++ b/Example/Pods/iOSPhotoEditor/Photo Editor/Photo Editor/PhotoEditor+Drawing.swift
@@ -59,7 +59,7 @@ extension PhotoEditorViewController {
     func drawLineFrom(_ fromPoint: CGPoint, toPoint: CGPoint) {
         // 1
 		let canvasSize = canvasImageView.frame.integral.size
-        UIGraphicsBeginImageContext(canvasSize)
+		UIGraphicsBeginImageContextWithOptions(canvasSize, false, 0)
         if let context = UIGraphicsGetCurrentContext() {
             canvasImageView.image?.draw(in: CGRect(x: 0, y: 0, width: canvasSize.width, height: canvasSize.height))
             // 2

--- a/Example/Pods/iOSPhotoEditor/Photo Editor/Photo Editor/PhotoEditor+Drawing.swift
+++ b/Example/Pods/iOSPhotoEditor/Photo Editor/Photo Editor/PhotoEditor+Drawing.swift
@@ -58,8 +58,8 @@ extension PhotoEditorViewController {
     
     func drawLineFrom(_ fromPoint: CGPoint, toPoint: CGPoint) {
         // 1
-		let canvasSize = canvasImageView.frame.integral.size
-		UIGraphicsBeginImageContextWithOptions(canvasSize, false, 0)
+        let canvasSize = canvasImageView.frame.integral.size
+        UIGraphicsBeginImageContextWithOptions(canvasSize, false, 0)
         if let context = UIGraphicsGetCurrentContext() {
             canvasImageView.image?.draw(in: CGRect(x: 0, y: 0, width: canvasSize.width, height: canvasSize.height))
             // 2
@@ -75,7 +75,7 @@ extension PhotoEditorViewController {
             // 5
             canvasImageView.image = UIGraphicsGetImageFromCurrentImageContext()
         }
-		UIGraphicsEndImageContext()
+        UIGraphicsEndImageContext()
     }
     
 }

--- a/Example/Pods/iOSPhotoEditor/Photo Editor/Photo Editor/PhotoEditor+Drawing.swift
+++ b/Example/Pods/iOSPhotoEditor/Photo Editor/Photo Editor/PhotoEditor+Drawing.swift
@@ -73,8 +73,8 @@ extension PhotoEditorViewController {
             context.strokePath()
             // 5
             canvasImageView.image = UIGraphicsGetImageFromCurrentImageContext()
-            UIGraphicsEndImageContext()
         }
+		UIGraphicsEndImageContext()
     }
     
 }


### PR DESCRIPTION
This small patch fixes an issue appeared with certain images while using the manual drawing tool.
If the canvas size had a non-integral frame size then the drawing goes even more blurry on every render-cycle.

Another small change is to use the device screen scale factor to match the canvas resolution with the device screen resolution avoid its pixelation. You could check its performance implication but I think it will be fine.

I attached some visuals about the issue I experienced in the example app:
<img width="384" alt="before" src="https://user-images.githubusercontent.com/8742665/45928519-597fda80-bf45-11e8-9258-2d7c75134aaf.png">

And the patched version:
<img width="384" alt="after" src="https://user-images.githubusercontent.com/8742665/45928558-df038a80-bf45-11e8-99cb-715c9ccfe356.png">

Many thanks for the great effort on this project,
bithug