### PR TITLE
Hoffofalltrades/fix text bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/Example/editorTest.xcodeproj/xcuserdata/joe.xcuserdatad
+/Example/editorTest.xcworkspace/xcuserdata/joe.xcuserdatad
+/Example/Pods/Pods.xcodeproj/xcuserdata/joe.xcuserdatad
+/Photo Editor/.DS_Store
+/Photo Editor/Photo Editor.xcodeproj/project.xcworkspace/xcuserdata/joe.xcuserdatad

--- a/Example/Pods/iOSPhotoEditor/Photo Editor/Photo Editor/PhotoEditor+Gestures.swift
+++ b/Example/Pods/iOSPhotoEditor/Photo Editor/Photo Editor/PhotoEditor+Gestures.swift
@@ -200,8 +200,15 @@ extension PhotoEditorViewController : UIGestureRecognizerDelegate  {
         if recognizer.state == .ended {
             imageViewToPan = nil
             lastPanPoint = nil
-            hideToolbar(hide: false)
+
+            if isTyping == true {
+                hideToolbar(hide: true)
+            } else {
+                hideToolbar(hide: false)
+            }
+            
             deleteView.isHidden = true
+
             let point = recognizer.location(in: self.view)
             
             if deleteView.frame.contains(point) { // Delete the view

--- a/Photo Editor/Photo Editor/PhotoEditor+Gestures.swift
+++ b/Photo Editor/Photo Editor/PhotoEditor+Gestures.swift
@@ -200,8 +200,15 @@ extension PhotoEditorViewController : UIGestureRecognizerDelegate  {
         if recognizer.state == .ended {
             imageViewToPan = nil
             lastPanPoint = nil
-            hideToolbar(hide: false)
+
+            if isTyping == true {
+                hideToolbar(hide: true)
+            } else {
+                hideToolbar(hide: false)
+            }
+            
             deleteView.isHidden = true
+
             let point = recognizer.location(in: self.view)
             
             if deleteView.frame.contains(point) { // Delete the view


### PR DESCRIPTION
When editing text and the keyboard is up, a user can drag the text. when they let go, the toolbar shows up and overlaps the done button. This fix stops that from happening.