### PR TITLE
fix: memory leak

### DIFF
--- a/iOSPhotoEditor/PhotoEditor+Font.swift
+++ b/iOSPhotoEditor/PhotoEditor+Font.swift
@@ -13,6 +13,10 @@ extension PhotoEditorViewController {
     
     //Resources don't load in main bundle we have to register the font
     func registerFont() {
+        if (UIFont.fontNames(forFamilyName: "icomoon").count != 0) {
+            return;
+        }
+        
         let bundle = Bundle(for: PhotoEditorViewController.self)
             let url =  bundle.url(forResource: "icomoon", withExtension: "ttf")
             

--- a/iOSPhotoEditor/PhotoEditorViewController.swift
+++ b/iOSPhotoEditor/PhotoEditorViewController.swift
@@ -105,6 +105,15 @@ public final class PhotoEditorViewController: UIViewController {
         hideControls()
     }
     
+    override public func viewDidDisappear(_ animated: Bool) {
+        // Cleanup
+        colorsCollectionViewDelegate.colorDelegate = nil;
+        colorsCollectionViewDelegate = nil;
+        
+        stickersViewController.stickersViewControllerDelegate = nil;
+        stickersViewController = nil;
+    }
+    
     func configureCollectionView() {
         let layout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
         layout.itemSize = CGSize(width: 30, height: 30)


### PR DESCRIPTION
There is a memory leak in the current implementation. It can be simulated with the following workflow - just open the editor for an image, then cancel it, then open another image and cancel that one as well (same goes if you accept the edit). The instances of the `PhotoEditorViewController` are not freed from memory. Similar thing happens if you decide to add a sticker/emoji. 

Also for some reason registering a font while it is already registered also causes some memory to be leaked (although not as big as the other one)

This PR fixes both leaks 😃 