### PR TITLE
Change deprecated UI_USER_INTERFACE_IDIOM

### DIFF
--- a/iOSPhotoEditor/CropView.swift
+++ b/iOSPhotoEditor/CropView.swift
@@ -257,7 +257,7 @@ open class CropView: UIView, UIScrollViewDelegate, UIGestureRecognizerDelegate, 
         let cropRect = convert(scrollView.frame, to: zoomingView)
         var ratio: CGFloat = 1.0
         let orientation = UIApplication.shared.statusBarOrientation
-        if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiom.pad || orientation.isPortrait) {
+        if (UIDevice.current.userInterfaceIdiom == UIUserInterfaceIdiom.pad || orientation.isPortrait) {
             ratio = AVMakeRect(aspectRatio: imageSize, insideRect: insetRect).width / imageSize.width
         } else {
             ratio = AVMakeRect(aspectRatio: imageSize, insideRect: insetRect).height / imageSize.height


### PR DESCRIPTION
With Xcode 13.3 I found this issue while archiving. UI_USER_INTERFACE_IDIOM is deprecated and would crash the archive with the newest Xcode.
See: https://developer.apple.com/documentation/uikit/1620016-ui_user_interface_idiom